### PR TITLE
Add default empty list value for IGNORE_WORDS variable

### DIFF
--- a/SpellCheckListener.py
+++ b/SpellCheckListener.py
@@ -28,7 +28,7 @@ class SpellCheckListener:
 
         # Fetch words to be ignored
         if self.PRE_RUNNER == 0:
-            self.IGNORE_WORDS = BuiltIn().get_variable_value("${IGNORE_WORDS}")
+            self.IGNORE_WORDS = BuiltIn().get_variable_value("${IGNORE_WORDS}", [])
             self.PRE_RUNNER = 1
 
         # get suite name


### PR DESCRIPTION
@adiralashiva8 I did this fix since if IGNORE_WORDS variable was left empty (undeclared), `if word not in self.IGNORE_WORDS` statement would raise an exception.